### PR TITLE
Security fixes & cleanup

### DIFF
--- a/autologin.c
+++ b/autologin.c
@@ -52,8 +52,9 @@ static char *tilde_to_path(char *path) {
 	if (*path == '~' && (homepath = getenv("HOME"))) {
 		static char newpath[256];
 		memset(newpath, 0, sizeof(newpath));
-		strncpy(newpath, homepath, 255);
-		strncat(newpath, path+1, 255);
+		strncpy(newpath, homepath, sizeof(newpath) - 1);
+		/* strncat is confusing, try not to overflow */
+		strncat(newpath, path+1, sizeof(newpath) - strlen(newpath) - 1);
 		return newpath;
 	}
 	return path;

--- a/interfaces.c
+++ b/interfaces.c
@@ -309,7 +309,8 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 	unsigned char *rest =
 	  (unsigned char *)(buffer + 20 + 14 + sizeof(struct udphdr));
 
-	if (((void *)rest - (void*)buffer) + datalen  > ETH_FRAME_LEN) {
+	/* Avoid integer overflow in check */
+	if (datalen > ETH_FRAME_LEN - ((void *)rest - (void*)buffer)) {
 		fprintf(stderr, _("packet size too large\n"));
 		return 0;
 	}

--- a/mndp.c
+++ b/mndp.c
@@ -125,7 +125,7 @@ int mndp(int timeout, int batch_mode)  {
 		memset(&addr, 0, addrlen);
 
 		/* Wait for a UDP packet */
-		result = recvfrom(sock, buff, MT_PACKET_LEN, 0, (struct sockaddr *)&addr, &addrlen);
+		result = recvfrom(sock, buff, sizeof(buff), 0, (struct sockaddr *)&addr, &addrlen);
 		if (result < 0) {
 			fprintf(stderr, _("An error occured. aborting\n"));
 			exit(1);

--- a/protocol.c
+++ b/protocol.c
@@ -64,21 +64,12 @@ int init_packet(struct mt_packet *packet, enum mt_ptype ptype, unsigned char *sr
 	/* dst ethernet address */
 	memcpy(data + 8, dstmac, ETH_ALEN);
 
-	if (mt_direction_fromserver) {
-		/* Session key */
-		sessionkey = htons(sessionkey);
-		memcpy(data + 16, &sessionkey, sizeof(sessionkey));
+	/* Session key */
+	sessionkey = htons(sessionkey);
+	memcpy(data + (mt_direction_fromserver ? 16 : 14), &sessionkey, sizeof(sessionkey));
 
-		/* Client type: Mac Telnet */
-		memcpy(data + 14, &mt_mactelnet_clienttype, sizeof(mt_mactelnet_clienttype));
-	} else {
-		/* Session key */
-		sessionkey = htons(sessionkey);
-		memcpy(data + 14, &sessionkey, sizeof(sessionkey));
-
-		/* Client type: Mac Telnet */
-		memcpy(data + 16, &mt_mactelnet_clienttype, sizeof(mt_mactelnet_clienttype));
-	}
+	/* Client type: Mac Telnet */
+	memcpy(data + (mt_direction_fromserver ? 14 : 16), &mt_mactelnet_clienttype, sizeof(mt_mactelnet_clienttype));
 
 	/* Received/sent data counter */
 	counter = htonl(counter);
@@ -89,11 +80,12 @@ int init_packet(struct mt_packet *packet, enum mt_ptype ptype, unsigned char *sr
 	return 22;
 }
 
-int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cpdata, int data_len) {
+int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cpdata, unsigned short data_len) {
 	unsigned char *data = packet->data + packet->size;
+	unsigned int act_size = data_len + (cptype == MT_CPTYPE_PLAINDATA ? 0 : MT_CPHEADER_LEN);
 
 	/* Something is really wrong. Packets should never become over 1500 bytes */
-	if (packet->size + MT_CPHEADER_LEN + data_len > MT_PACKET_LEN) {
+	if (packet->size + act_size > MT_PACKET_LEN) {
 		fprintf(stderr, _("add_control_packet: ERROR, too large packet. Exceeds %d bytes\n"), MT_PACKET_LEN);
 		return -1;
 		//exit(1);
@@ -108,7 +100,7 @@ int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cp
 	}
 
 	/* Control Packet Magic id */
-	memcpy(data,  mt_mactelnet_cpmagic, sizeof(mt_mactelnet_cpmagic));
+	memcpy(data, mt_mactelnet_cpmagic, sizeof(mt_mactelnet_cpmagic));
 
 	/* Control packet type */
 	data[4] = cptype;
@@ -129,9 +121,9 @@ int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cp
 		memcpy(data + MT_CPHEADER_LEN, cpdata, data_len);
 	}
 
-	packet->size += MT_CPHEADER_LEN + data_len;
+	packet->size += act_size;
 	/* Control packet header length + data length */
-	return MT_CPHEADER_LEN + data_len;
+	return act_size;
 }
 
 int init_pingpacket(struct mt_packet *packet, unsigned char *srcmac, unsigned char *dstmac) {
@@ -181,21 +173,12 @@ void parse_packet(unsigned char *data, struct mt_mactelnet_hdr *pkthdr) {
 	/* dst ethernet addr */
 	memcpy(pkthdr->dstaddr, data + 8, ETH_ALEN);
 
-	if (mt_direction_fromserver) {
-		/* Session key */
-		memcpy(&(pkthdr->seskey), data + 14, sizeof(pkthdr->seskey));
-		pkthdr->seskey = ntohs(pkthdr->seskey);
+	/* Session key */
+	memcpy(&(pkthdr->seskey), data + (mt_direction_fromserver ? 14 : 16), sizeof(pkthdr->seskey));
+	pkthdr->seskey = ntohs(pkthdr->seskey);
 
-		/* server type */
-		memcpy(&(pkthdr->clienttype), data + 16, 2);
-	} else {
-		/* server type */
-		memcpy(&(pkthdr->clienttype), data + 14, 2);
-
-		/* Session key */
-		memcpy(&(pkthdr->seskey), data + 16, sizeof(pkthdr->seskey));
-		pkthdr->seskey = ntohs(pkthdr->seskey);
-	}
+	/* server type */
+	memcpy(&(pkthdr->clienttype), data + (mt_direction_fromserver ? 16 : 14), 2);
 
 	/* Received/sent data counter */
 	memcpy(&(pkthdr->counter), data + 18, sizeof(pkthdr->counter));
@@ -206,7 +189,7 @@ void parse_packet(unsigned char *data, struct mt_mactelnet_hdr *pkthdr) {
 }
 
 
-int parse_control_packet(unsigned char *packetdata, int data_len, struct mt_mactelnet_control_hdr *cpkthdr) {
+int parse_control_packet(unsigned char *packetdata, unsigned short data_len, struct mt_mactelnet_control_hdr *cpkthdr) {
 	static unsigned char *int_data;
 	static unsigned int int_data_len;
 	static unsigned int int_pos;
@@ -216,7 +199,7 @@ int parse_control_packet(unsigned char *packetdata, int data_len, struct mt_mact
 	   and then several times for each control packets. Letting this function
 	   control the data position. */
 	if (packetdata != NULL) {
-		if (data_len <= 0) {
+		if (data_len == 0) {
 			return 0;
 		}
 
@@ -234,7 +217,7 @@ int parse_control_packet(unsigned char *packetdata, int data_len, struct mt_mact
 	data = int_data + int_pos;
 
 	/* Check for valid minimum packet length & magic header */
-	if (int_data_len >= 9 && memcmp(data, &mt_mactelnet_cpmagic, 4) == 0) {
+	if ((int_data_len - int_pos) >= MT_CPHEADER_LEN && memcmp(data, &mt_mactelnet_cpmagic, 4) == 0) {
 
 		/* Control packet type */
 		cpkthdr->cptype = data[4];
@@ -244,15 +227,15 @@ int parse_control_packet(unsigned char *packetdata, int data_len, struct mt_mact
 		cpkthdr->length = ntohl(cpkthdr->length);
 
 		/* We want no buffer overflows */
-		if (cpkthdr->length >= MT_PACKET_LEN - 22 - int_pos) {
-			cpkthdr->length = MT_PACKET_LEN - 1 - 22 - int_pos;
+		if (cpkthdr->length > int_data_len - MT_CPHEADER_LEN - int_pos) {
+			cpkthdr->length = int_data_len - MT_CPHEADER_LEN - int_pos;
 		}
 
 		/* Set pointer to actual data */
-		cpkthdr->data = data + 9;
+		cpkthdr->data = data + MT_CPHEADER_LEN;
 
 		/* Remember old position, for next call */
-		int_pos += cpkthdr->length + 9;
+		int_pos += cpkthdr->length + MT_CPHEADER_LEN;
 
 		/* Read data successfully */
 		return 1;
@@ -327,7 +310,7 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 
 	p = data + sizeof(struct mt_mndp_hdr);
 
-	while(p < data + packet_len) {
+	while(p + 4 < data + packet_len) {
 		unsigned short type, len;
 
 		memcpy(&type, p, 2);
@@ -354,8 +337,8 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_IDENTITY:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->identity, p, len);
@@ -363,8 +346,8 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_PLATFORM:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->platform, p, len);
@@ -372,8 +355,8 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_VERSION:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->version, p, len);
@@ -381,14 +364,16 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_TIMESTAMP:
-				memcpy(&packetp->uptime, p, 4);
-				/* Seems like ping uptime is transmitted as little endian? */
-				packetp->uptime = le32toh(packetp->uptime);
+				if (len >= 4) {
+					memcpy(&packetp->uptime, p, 4);
+					/* Seems like ping uptime is transmitted as little endian? */
+					packetp->uptime = le32toh(packetp->uptime);
+				}
 				break;
 
 			case MT_MNDPTYPE_HARDWARE:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->hardware, p, len);
@@ -396,8 +381,8 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_SOFTID:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->softid, p, len);
@@ -405,8 +390,8 @@ struct mt_mndp_info *parse_mndp(const unsigned char *data, const int packet_len)
 				break;
 
 			case MT_MNDPTYPE_IFNAME:
-				if (len > MT_MNDP_MAX_STRING_LENGTH) {
-					len = MT_MNDP_MAX_STRING_LENGTH;
+				if (len >= MT_MNDP_MAX_STRING_SIZE) {
+					len = MT_MNDP_MAX_STRING_SIZE - 1;
 				}
 
 				memcpy(packetp->ifname, p, len);
@@ -491,7 +476,7 @@ int query_mndp(const char *identity, unsigned char *mac) {
 		}
 
 		/* Read UDP packet */
-		length = recvfrom(sock, buff, MT_PACKET_LEN, 0, 0, 0);
+		length = recvfrom(sock, buff, sizeof(buff), 0, 0, 0);
 		if (length < 0) {
 			goto done;
 		}

--- a/protocol.h
+++ b/protocol.h
@@ -27,7 +27,7 @@
 #define MT_MACTELNET_PORT 20561
 
 #define MT_MNDP_PORT 5678
-#define MT_MNDP_MAX_STRING_LENGTH 128
+#define MT_MNDP_MAX_STRING_SIZE 128
 #define MT_MNDP_BROADCAST_INTERVAL 30
 
 #define MT_MNDP_TIMEOUT 5
@@ -55,7 +55,7 @@ enum mt_ptype {
 /* Control packet type */
 enum mt_cptype {
 	MT_CPTYPE_BEGINAUTH,
-	MT_CPTYPE_ENCRYPTIONKEY,
+	MT_CPTYPE_PASSSALT,
 	MT_CPTYPE_PASSWORD,
 	MT_CPTYPE_USERNAME,
 	MT_CPTYPE_TERM_TYPE,
@@ -107,12 +107,12 @@ struct mt_mactelnet_control_hdr {
 struct mt_mndp_info {
 	struct mt_mndp_hdr header;
 	unsigned char address[ETH_ALEN];
-	char identity[MT_MNDP_MAX_STRING_LENGTH];
-	char version[MT_MNDP_MAX_STRING_LENGTH];
-	char platform[MT_MNDP_MAX_STRING_LENGTH];
-	char hardware[MT_MNDP_MAX_STRING_LENGTH];
-	char softid[MT_MNDP_MAX_STRING_LENGTH];
-	char ifname[MT_MNDP_MAX_STRING_LENGTH];
+	char identity[MT_MNDP_MAX_STRING_SIZE];
+	char version[MT_MNDP_MAX_STRING_SIZE];
+	char platform[MT_MNDP_MAX_STRING_SIZE];
+	char hardware[MT_MNDP_MAX_STRING_SIZE];
+	char softid[MT_MNDP_MAX_STRING_SIZE];
+	char ifname[MT_MNDP_MAX_STRING_SIZE];
 	unsigned int uptime;
 };
 
@@ -123,9 +123,9 @@ struct mt_packet {
 
 /* MacTelnet/Winbox packets */
 extern int init_packet(struct mt_packet *packet, enum mt_ptype ptype, unsigned char *srcmac, unsigned char *dstmac, unsigned short sessionkey, unsigned int counter);
-extern int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cpdata, int data_len);
+extern int add_control_packet(struct mt_packet *packet, enum mt_cptype cptype, void *cpdata, unsigned short data_len);
 extern void parse_packet(unsigned char *data, struct mt_mactelnet_hdr *pkthdr);
-extern int parse_control_packet(unsigned char *data, int data_len, struct mt_mactelnet_control_hdr *cpkthdr);
+extern int parse_control_packet(unsigned char *data, unsigned short data_len, struct mt_mactelnet_control_hdr *cpkthdr);
 
 /* MAC-Ping packets */
 int init_pingpacket(struct mt_packet *packet, unsigned char *srcmac, unsigned char *dstmac);
@@ -154,7 +154,7 @@ extern unsigned char mt_direction_fromserver;
 /* Debugging stuff */
 #if defined(DEBUG_PROTO)
 #ifndef hexdump_defined
-void hexdump(const char *title, const void *buf, int len)
+void hexdump(const char *title, const void *buf, unsigned short len)
 {
     int i;
     unsigned char *data = (unsigned char *)buf;

--- a/users.c
+++ b/users.c
@@ -46,6 +46,7 @@ void read_userfile() {
 	while ( fgets(line, sizeof line, file) ) {
 		char *user;
 		char *password;
+		size_t size;
 
 		user = strtok(line, ":");
 		password = strtok(NULL, "\n");
@@ -60,8 +61,11 @@ void read_userfile() {
 			exit(1);
 		}
 
-		memcpy(cred->username, user, strlen(user) < MT_CRED_LEN - 1? strlen(user) : MT_CRED_LEN);
-		memcpy(cred->password, password, strlen(password)  < MT_CRED_LEN - 1? strlen(password)  : MT_CRED_LEN);
+		/* verify that the username & password will be '\0' terminated */
+		memcpy(cred->username, user, size = (strlen(user) < MT_CRED_LEN ? strlen(user) : MT_CRED_LEN - 1));
+		cred->username[size] = '\0';
+		memcpy(cred->password, password, size = (strlen(password) < MT_CRED_LEN ? strlen(password) : MT_CRED_LEN - 1));
+		cred->password[size] = '\0';
 		DL_APPEND(mt_users, cred);
 	}
 	fclose(file);


### PR DESCRIPTION
Security fixes and code cleanup:
1. Fixed buffer-overflows in mactelnet-client
2. Fixed buffer-overreads in mactelnetd
3. Changed terminology from "key" to "salt"
4. Added extensive use of the protocol's macros